### PR TITLE
Waiting $pidfile instead of $pid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM rabbitmq:alpine
 
 ENV RABBIT_USER=taiga \
 		RABBIT_PASSWORD=qwerty \
-		RABBIT_VHOST=taiga
+		RABBIT_VHOST=taiga \
+    RABBITMQ_ERLANG_COOKIE=taiga \
+    RABBITMQ_PID_FILE=$RABBITMQ_DATA_DIR/rabbitmq.pid
 
 COPY start.sh /start.sh
 

--- a/start.sh
+++ b/start.sh
@@ -10,13 +10,7 @@ if [ ! -f $RABBIT_INITIALIZED_LOCK ]; then
     touch $RABBIT_INITIALIZED_LOCK
 
     echo 'Waiting for rabbitmq to start...'
-    ok=1
-    while [ $ok -gt 0 ]; do
-        sleep 1
-        rabbit_pid=$(ls -1 /var/lib/rabbitmq/mnesia/rabbit*.pid)
-        ok=$?
-    done
-    rabbitmqctl wait $rabbit_pid
+    rabbitmqctl wait $RABBITMQ_PID_FILE
 
     echo 'Initializing rabbitmq vhost and user...'
     rabbitmqctl add_user $RABBIT_USER $RABBIT_PASSWORD

--- a/start.sh
+++ b/start.sh
@@ -13,7 +13,7 @@ if [ ! -f $RABBIT_INITIALIZED_LOCK ]; then
     ok=1
     while [ $ok -gt 0 ]; do
         sleep 1
-        rabbit_pid=$(cat /var/lib/rabbitmq/mnesia/rabbit*.pid)
+        rabbit_pid=$(ls -1 /var/lib/rabbitmq/mnesia/rabbit*.pid)
         ok=$?
     done
     rabbitmqctl wait $rabbit_pid


### PR DESCRIPTION
I found it seems to timeout very often with a message `timeout value 10000` and
it will be failed to wait for the process.

> wait pid_file, wait --pid pid
>
> https://www.rabbitmq.com/rabbitmqctl.8.html#wait

Thank you for the helpful images.